### PR TITLE
PEP 585 steps 7-8: Implement repr for GenericAlias

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -65,6 +65,14 @@ class BaseTest(unittest.TestCase):
         self.assertIs(t.__origin__, MyList)
         self.assertEqual(t.__parameters__, (int,))
 
+    def test_repr(self):
+        class MyList(list):
+            pass
+        self.assertEqual(repr(list[str]), 'list[str]')
+        self.assertEqual(repr(list[()]), 'list[()]')
+        self.assertEqual(repr(MyList[int]), 'test.test_genericalias.BaseTest.test_repr.<locals>.MyList[int]')
+        self.assertEqual(repr(list[str]()), '[]')  # instances should keep their normal repr
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -70,7 +70,8 @@ class BaseTest(unittest.TestCase):
             pass
         self.assertEqual(repr(list[str]), 'list[str]')
         self.assertEqual(repr(list[()]), 'list[()]')
-        self.assertEqual(repr(MyList[int]), 'test.test_genericalias.BaseTest.test_repr.<locals>.MyList[int]')
+        self.assertEqual(repr(tuple[int, ...]), 'tuple[int, ...]')
+        self.assertTrue(repr(MyList[int]).endswith('BaseTest.test_repr.<locals>.MyList[int]'))
         self.assertEqual(repr(list[str]()), '[]')  # instances should keep their normal repr
 
 


### PR DESCRIPTION
This is basically a direct port of the Python code, modulo the loop inside was broken out so I didn't have to concat a new tuple to the parameters tuple.
