### PR TITLE
Implement PEP 585 for collections.deque and collections.defaultdict

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -1,13 +1,13 @@
 """Tests for C-implemented GenericAlias."""
 
 import unittest
-
+from collections import defaultdict, deque
 
 class BaseTest(unittest.TestCase):
     """Test basics."""
 
     def test_subscriptable(self):
-        for t in tuple, list, dict, set, frozenset:
+        for t in tuple, list, dict, set, frozenset, defaultdict, deque:
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):
                 alias = t[int]
@@ -22,7 +22,7 @@ class BaseTest(unittest.TestCase):
                     t[int]
 
     def test_instantiate(self):
-        for t in tuple, list, dict, set, frozenset:
+        for t in tuple, list, dict, set, frozenset, defaultdict, deque:
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):
                 alias = t[int]
@@ -30,6 +30,12 @@ class BaseTest(unittest.TestCase):
                 if t is dict:
                     self.assertEqual(alias(iter([('a', 1), ('b', 2)])), dict(a=1, b=2))
                     self.assertEqual(alias(a=1, b=2), dict(a=1, b=2))
+                elif t is defaultdict:
+                    def default():
+                        return 'value'
+                    a = alias(default)
+                    d = defaultdict(default)
+                    self.assertEqual(a['test'], d['test'])
                 else:
                     self.assertEqual(alias(iter((1, 2, 3))), t((1, 2, 3)))
 

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1605,6 +1605,8 @@ static PyMethodDef deque_methods[] = {
         METH_FASTCALL,            rotate_doc},
     {"__sizeof__",              (PyCFunction)deque_sizeof,
         METH_NOARGS,             sizeof_doc},
+    {"__class_getitem__",       (PyCFunction)Py_GenericAlias,
+        METH_O|METH_CLASS,       PyDoc_STR("See PEP 585")},
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -2067,6 +2069,8 @@ static PyMethodDef defdict_methods[] = {
      defdict_copy_doc},
     {"__reduce__", (PyCFunction)defdict_reduce, METH_NOARGS,
      reduce_doc},
+    {"__class_getitem__", (PyCFunction)Py_GenericAlias, METH_O|METH_CLASS,
+     PyDoc_STR("See PEP 585")},
     {NULL}
 };
 


### PR DESCRIPTION
These are (I think) the last two classes implemented in C that should be made generic.