### PR TITLE
Make collections.abc.* generic

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -8,6 +8,7 @@ Unit tests are in test_collections.
 
 from abc import ABCMeta, abstractmethod
 import sys
+from types import GenericAlias
 
 __all__ = ["Awaitable", "Coroutine",
            "AsyncIterable", "AsyncIterator", "AsyncGenerator",
@@ -65,10 +66,6 @@ async def _ag(): yield
 _ag = _ag()
 async_generator = type(_ag)
 del _ag
-
-
-# needed for making various ABCs generic
-GenericAlias = type(list[str])
 
 
 ### ONE-TRICK PONIES ###

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -67,6 +67,10 @@ async_generator = type(_ag)
 del _ag
 
 
+# needed for making various ABCs generic
+GenericAlias = type(list[str])
+
+
 ### ONE-TRICK PONIES ###
 
 def _check_methods(C, *methods):
@@ -110,6 +114,10 @@ class Awaitable(metaclass=ABCMeta):
             return _check_methods(C, "__await__")
         return NotImplemented
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
 
 class Coroutine(Awaitable):
 
@@ -151,6 +159,10 @@ class Coroutine(Awaitable):
             return _check_methods(C, '__await__', 'send', 'throw', 'close')
         return NotImplemented
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
 
 Coroutine.register(coroutine)
 
@@ -168,6 +180,10 @@ class AsyncIterable(metaclass=ABCMeta):
         if cls is AsyncIterable:
             return _check_methods(C, "__aiter__")
         return NotImplemented
+
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
 
 
 class AsyncIterator(AsyncIterable):
@@ -187,6 +203,10 @@ class AsyncIterator(AsyncIterable):
         if cls is AsyncIterator:
             return _check_methods(C, "__anext__", "__aiter__")
         return NotImplemented
+
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
 
 
 class AsyncGenerator(AsyncIterator):
@@ -236,6 +256,10 @@ class AsyncGenerator(AsyncIterator):
                                   'asend', 'athrow', 'aclose')
         return NotImplemented
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
 
 AsyncGenerator.register(async_generator)
 
@@ -255,6 +279,10 @@ class Iterable(metaclass=ABCMeta):
             return _check_methods(C, "__iter__")
         return NotImplemented
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
 
 class Iterator(Iterable):
 
@@ -273,6 +301,11 @@ class Iterator(Iterable):
         if cls is Iterator:
             return _check_methods(C, '__iter__', '__next__')
         return NotImplemented
+
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
 
 Iterator.register(bytes_iterator)
 Iterator.register(bytearray_iterator)
@@ -304,6 +337,10 @@ class Reversible(Iterable):
         if cls is Reversible:
             return _check_methods(C, "__reversed__", "__iter__")
         return NotImplemented
+
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
 
 
 class Generator(Iterator):
@@ -353,6 +390,11 @@ class Generator(Iterator):
                                   'send', 'throw', 'close')
         return NotImplemented
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
+
 Generator.register(generator)
 
 
@@ -385,6 +427,11 @@ class Container(metaclass=ABCMeta):
             return _check_methods(C, "__contains__")
         return NotImplemented
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
+
 class Collection(Sized, Iterable, Container):
 
     __slots__ = ()
@@ -394,6 +441,11 @@ class Collection(Sized, Iterable, Container):
         if cls is Collection:
             return _check_methods(C,  "__len__", "__iter__", "__contains__")
         return NotImplemented
+
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
 
 class Callable(metaclass=ABCMeta):
 
@@ -408,6 +460,10 @@ class Callable(metaclass=ABCMeta):
         if cls is Callable:
             return _check_methods(C, "__call__")
         return NotImplemented
+
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
 
 
 ### SETS ###
@@ -550,6 +606,11 @@ class Set(Collection):
             h = 590923713
         return h
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
+
 Set.register(frozenset)
 
 
@@ -632,6 +693,11 @@ class MutableSet(Set):
                 self.discard(value)
         return self
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
+
 MutableSet.register(set)
 
 
@@ -688,6 +754,11 @@ class Mapping(Collection):
 
     __reversed__ = None
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
+
 Mapping.register(mappingproxy)
 
 
@@ -704,6 +775,10 @@ class MappingView(Sized):
     def __repr__(self):
         return '{0.__class__.__name__}({0._mapping!r})'.format(self)
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
 
 class KeysView(MappingView, Set):
 
@@ -718,6 +793,11 @@ class KeysView(MappingView, Set):
 
     def __iter__(self):
         yield from self._mapping
+
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
 
 KeysView.register(dict_keys)
 
@@ -743,6 +823,11 @@ class ItemsView(MappingView, Set):
         for key in self._mapping:
             yield (key, self._mapping[key])
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
+
 ItemsView.register(dict_items)
 
 
@@ -760,6 +845,11 @@ class ValuesView(MappingView, Collection):
     def __iter__(self):
         for key in self._mapping:
             yield self._mapping[key]
+
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
 
 ValuesView.register(dict_values)
 
@@ -847,6 +937,11 @@ class MutableMapping(Mapping):
             self[key] = default
         return default
 
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
+
 MutableMapping.register(dict)
 
 
@@ -913,6 +1008,11 @@ class Sequence(Reversible, Collection):
     def count(self, value):
         'S.count(value) -> integer -- return number of occurrences of value'
         return sum(1 for v in self if v is value or v == value)
+
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
 
 Sequence.register(tuple)
 Sequence.register(str)
@@ -999,6 +1099,11 @@ class MutableSequence(Sequence):
     def __iadd__(self, values):
         self.extend(values)
         return self
+
+    def __class_getitem__(cls, item):
+        """Internal: PEP 585."""
+        return GenericAlias(cls, item)
+
 
 MutableSequence.register(list)
 MutableSequence.register(bytearray)  # Multiply inheriting, see ByteString

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -156,10 +156,6 @@ class Coroutine(Awaitable):
             return _check_methods(C, '__await__', 'send', 'throw', 'close')
         return NotImplemented
 
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
-
 
 Coroutine.register(coroutine)
 
@@ -200,10 +196,6 @@ class AsyncIterator(AsyncIterable):
         if cls is AsyncIterator:
             return _check_methods(C, "__anext__", "__aiter__")
         return NotImplemented
-
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
 
 
 class AsyncGenerator(AsyncIterator):
@@ -253,10 +245,6 @@ class AsyncGenerator(AsyncIterator):
                                   'asend', 'athrow', 'aclose')
         return NotImplemented
 
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
-
 
 AsyncGenerator.register(async_generator)
 
@@ -299,10 +287,6 @@ class Iterator(Iterable):
             return _check_methods(C, '__iter__', '__next__')
         return NotImplemented
 
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
-
 
 Iterator.register(bytes_iterator)
 Iterator.register(bytearray_iterator)
@@ -334,10 +318,6 @@ class Reversible(Iterable):
         if cls is Reversible:
             return _check_methods(C, "__reversed__", "__iter__")
         return NotImplemented
-
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
 
 
 class Generator(Iterator):
@@ -387,10 +367,6 @@ class Generator(Iterator):
                                   'send', 'throw', 'close')
         return NotImplemented
 
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
-
 
 Generator.register(generator)
 
@@ -438,10 +414,6 @@ class Collection(Sized, Iterable, Container):
         if cls is Collection:
             return _check_methods(C,  "__len__", "__iter__", "__contains__")
         return NotImplemented
-
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
 
 
 class Callable(metaclass=ABCMeta):
@@ -603,10 +575,6 @@ class Set(Collection):
             h = 590923713
         return h
 
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
-
 
 Set.register(frozenset)
 
@@ -690,10 +658,6 @@ class MutableSet(Set):
                 self.discard(value)
         return self
 
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
-
 
 MutableSet.register(set)
 
@@ -751,10 +715,6 @@ class Mapping(Collection):
 
     __reversed__ = None
 
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
-
 
 Mapping.register(mappingproxy)
 
@@ -791,10 +751,6 @@ class KeysView(MappingView, Set):
     def __iter__(self):
         yield from self._mapping
 
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
-
 
 KeysView.register(dict_keys)
 
@@ -820,10 +776,6 @@ class ItemsView(MappingView, Set):
         for key in self._mapping:
             yield (key, self._mapping[key])
 
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
-
 
 ItemsView.register(dict_items)
 
@@ -842,10 +794,6 @@ class ValuesView(MappingView, Collection):
     def __iter__(self):
         for key in self._mapping:
             yield self._mapping[key]
-
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
 
 
 ValuesView.register(dict_values)
@@ -934,10 +882,6 @@ class MutableMapping(Mapping):
             self[key] = default
         return default
 
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
-
 
 MutableMapping.register(dict)
 
@@ -1005,10 +949,6 @@ class Sequence(Reversible, Collection):
     def count(self, value):
         'S.count(value) -> integer -- return number of occurrences of value'
         return sum(1 for v in self if v is value or v == value)
-
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
 
 
 Sequence.register(tuple)
@@ -1096,10 +1036,6 @@ class MutableSequence(Sequence):
     def __iadd__(self, values):
         self.extend(values)
         return self
-
-    def __class_getitem__(cls, item):
-        """Internal: PEP 585."""
-        return GenericAlias(cls, item)
 
 
 MutableSequence.register(list)

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -962,10 +962,6 @@ class UserDict(_collections_abc.MutableMapping):
         if kwargs:
             self.update(kwargs)
 
-    # It's a generic class, just like dict.
-    def __class_getitem__(cls, item):
-        return _GenericAlias(cls, item)
-
     def __len__(self): return len(self.data)
     def __getitem__(self, key):
         if key in self.data:
@@ -1029,8 +1025,6 @@ class UserList(_collections_abc.MutableSequence):
                 self.data[:] = initlist.data[:]
             else:
                 self.data = list(initlist)
-    def __class_getitem__(cls, item):
-        return _GenericAlias(cls, item)
     def __repr__(self): return repr(self.data)
     def __lt__(self, other): return self.data <  self.__cast(other)
     def __le__(self, other): return self.data <= self.__cast(other)

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -1,20 +1,36 @@
 """Tests for C-implemented GenericAlias."""
 
 import unittest
-from collections import defaultdict, deque
+from collections import (
+    defaultdict, deque, OrderedDict, Counter, UserDict, UserList
+)
+from collections.abc import *
 from contextlib import AbstractContextManager, AbstractAsyncContextManager
 from io import IOBase
 from re import Pattern, Match
+
 
 class BaseTest(unittest.TestCase):
     """Test basics."""
 
     def test_subscriptable(self):
         for t in (tuple, list, dict, set, frozenset,
-                  defaultdict, deque,
+                  defaultdict, deque, 
+                  OrderedDict, Counter, UserDict, UserList,
                   IOBase,
                   Pattern, Match,
                   AbstractContextManager, AbstractAsyncContextManager,
+                  Awaitable, Coroutine,
+                  AsyncIterable, AsyncIterator,
+                  AsyncGenerator, Generator,
+                  Iterable, Iterator,
+                  Reversible,
+                  Container, Collection,
+                  Callable,
+                  Set, MutableSet,
+                  Mapping, MutableMapping, MappingView,
+                  KeysView, ItemsView, ValuesView,
+                  Sequence, MutableSequence,
                   ):
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):
@@ -23,7 +39,7 @@ class BaseTest(unittest.TestCase):
                 self.assertEqual(alias.__parameters__, (int,))
 
     def test_unsubscriptable(self):
-        for t in int, str, float:
+        for t in int, str, float, Sized, Hashable:
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):
                 with self.assertRaises(TypeError):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1083,6 +1083,10 @@ class Protocol(Generic, metaclass=_ProtocolMeta):
 
             # Second, perform the actual structural compatibility check.
             for attr in _get_protocol_attrs(cls):
+                # Requiring people to implement this on e.g. iterable classes
+                # would break existing code
+                if attr == '__class_getitem__':
+                    continue
                 for base in other.__mro__:
                     # Check if the members appears in the class dictionary...
                     if attr in base.__dict__:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -946,7 +946,7 @@ _TYPING_INTERNALS = ['__parameters__', '__orig_bases__',  '__orig_class__',
 
 _SPECIAL_NAMES = ['__abstractmethods__', '__annotations__', '__dict__', '__doc__',
                   '__init__', '__module__', '__new__', '__slots__',
-                  '__subclasshook__', '__weakref__']
+                  '__subclasshook__', '__weakref__', '__class_getitem__']
 
 # These special attributes will be not collected as protocol members.
 EXCLUDED_ATTRIBUTES = _TYPING_INTERNALS + _SPECIAL_NAMES + ['_MutableMapping__marker']
@@ -1083,10 +1083,6 @@ class Protocol(Generic, metaclass=_ProtocolMeta):
 
             # Second, perform the actual structural compatibility check.
             for attr in _get_protocol_attrs(cls):
-                # Requiring people to implement this on e.g. iterable classes
-                # would break existing code
-                if attr == '__class_getitem__':
-                    continue
                 for base in other.__mro__:
                     # Check if the members appears in the class dictionary...
                     if attr in base.__dict__:


### PR DESCRIPTION
... and add tests for them.

I also *removed* `__class_getitem__` from `collections.UserDict`/`collections.UserList`, since those inherit from `collections.abc` types (which is a nice test inheritance works for these types)!'

I didn't import `types.GenericAlias` in `_collections_abc` since this seems to be on the hot path for startup, and I figured that would be bad.