### PR TITLE
GenericAlias pickle support

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -11,6 +11,8 @@ from io import IOBase
 from re import Pattern, Match
 from types import GenericAlias
 
+from typing import TypeVar
+T = TypeVar('T')
 
 class BaseTest(unittest.TestCase):
     """Test basics."""
@@ -175,9 +177,12 @@ class BaseTest(unittest.TestCase):
             issubclass(L, list[str])
 
     def test_pickle(self):
-        alias = GenericAlias(list, str)
+        alias = GenericAlias(list, T)
         s = pickle.dumps(alias)
-        self.assertEqual(alias, pickle.loads(s))
+        loaded = pickle.loads(s)
+        self.assertEqual(alias.__origin__, loaded.__origin__)
+        self.assertEqual(alias.__args__, loaded.__args__)
+        self.assertEqual(alias.__parameters__, loaded.__parameters__)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -1,6 +1,7 @@
 """Tests for C-implemented GenericAlias."""
 
 import unittest
+import pickle
 from collections import (
     defaultdict, deque, OrderedDict, Counter, UserDict, UserList
 )
@@ -8,6 +9,7 @@ from collections.abc import *
 from contextlib import AbstractContextManager, AbstractAsyncContextManager
 from io import IOBase
 from re import Pattern, Match
+from types import GenericAlias
 
 
 class BaseTest(unittest.TestCase):
@@ -171,6 +173,11 @@ class BaseTest(unittest.TestCase):
         self.assertTrue(issubclass(L, list))
         with self.assertRaises(TypeError):
             issubclass(L, list[str])
+
+    def test_pickle(self):
+        alias = GenericAlias(list, str)
+        s = pickle.dumps(alias)
+        self.assertEqual(alias, pickle.loads(s))
 
 
 if __name__ == "__main__":

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -2077,10 +2077,18 @@ ga_subclasscheck(PyObject *self, PyObject *Py_UNUSED(ignored))
                         self);
 }
 
+static PyObject *
+ga_reduce(gaobject *self, PyObject *Py_UNUSED(ignored))
+{
+    return Py_BuildValue("(O(OOO))", Py_TYPE(self),
+                         self->origin, self->args, self->parameters);
+}
+
 static PyMethodDef ga_methods[] = {
     {"__mro_entries__", ga_mro_entries, METH_O},
     {"__instancecheck__", ga_instancecheck, METH_O},
     {"__subclasscheck__", ga_subclasscheck, METH_O},
+    {"__reduce__", ga_reduce, METH_NOARGS},
     {0}
 };
 


### PR DESCRIPTION
So I basically copied the implementation in [`range_reduce`](https://github.com/python/cpython/blob/46874c26ee1fc752e2e6930efa1d223b2351edb8/Objects/rangeobject.c#L609), but it is failing the test for some reason with the following traceback:

```
Traceback (most recent call last):
  File "C:\Users\ethanhs\cpython\Lib\test\test_genericalias.py", line 179, in test_pickle
    s = pickle.dumps(alias)
TypeError: object.__reduce_ex__() takes exactly one argument (0 given)
```
I'm not really sure why this would happen, and my efforts to fix it haven't worked.