### PR TITLE
Make __parameters__ lazy

### DIFF
--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1963,14 +1963,13 @@ make_parameters(PyObject *args)
     return parameters;
 }
 
-_Py_IDENTIFIER(__parameters__);
-
 static PyObject *
 ga_getitem(PyObject *self, PyObject *item)
 {
     gaobject *alias = (gaobject *)self;
     // do a lookup for __parameters__ so it gets populated (if not already)
     if (alias->parameters == NULL) {
+        _Py_IDENTIFIER(__parameters__);
         PyObject *params = _PyObject_GetAttrId(self, &PyId___parameters__);
         if (params == NULL) {
             return NULL;


### PR DESCRIPTION
I believe this is all that is needed to make `__parameters__` be computed lazily. I wasn't entirely sure how best to test this, so suggestions welcome.

Also I realized that in `__setstate__` we unconditionally populate `__parameters__`. Perhaps this should changed to be lazily computed?