### PR TITLE
Disassembler

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -27,6 +27,8 @@ struct _PyOpcache {
 /* Private API */
 int _PyCode_InitOpcache(PyCodeObject *co);
 
+#define _PyCode_CODE(co) \
+    co->co_optimized_code ? co->co_optimized_code : co->co_code;
 
 #ifdef __cplusplus
 }

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -641,9 +641,16 @@ member_get_doc(PyMemberDescrObject *descr, void *closure)
     return PyUnicode_FromString(descr->d_member->doc);
 }
 
+static PyObject *
+member_get_offset(PyMemberDescrObject *descr, void *closure)
+{
+    return PyLong_FromSsize_t(descr->d_member->offset);
+}
+
 static PyGetSetDef member_getset[] = {
     {"__doc__", (getter)member_get_doc},
     {"__qualname__", (getter)descr_get_qualname},
+    {"_offset", (getter)member_get_offset},
     {0}
 };
 

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -109,6 +109,7 @@ top_block(int64_t stack)
 static int64_t *
 markblocks(PyCodeObject *code_obj, int len)
 {
+    // XXX (eric) Use _PyCode_CODE() here?
     const _Py_CODEUNIT *code =
         (const _Py_CODEUNIT *)PyBytes_AS_STRING(code_obj->co_code);
     int64_t *blocks = PyMem_New(int64_t, len+1);
@@ -399,6 +400,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
 
     /* PyCode_NewWithPosOnlyArgs limits co_code to be under INT_MAX so this
      * should never overflow. */
+    // XXX (eric) Use _PyCode_CODE() here?
     int len = (int)(PyBytes_GET_SIZE(f->f_code->co_code) / sizeof(_Py_CODEUNIT));
     int *lines = marklines(f->f_code, len);
     if (lines == NULL) {

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -346,6 +346,7 @@ _PyGen_yf(PyGenObject *gen)
     PyFrameObject *f = gen->gi_frame;
 
     if (f) {
+        // XXX (eric) Use _PyCode_CODE() here?
         PyObject *bytecode = f->f_code->co_code;
         unsigned char *code = (unsigned char *)PyBytes_AS_STRING(bytecode);
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1448,7 +1448,7 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
     consts = co->co_consts;
     fastlocals = f->f_localsplus;
     freevars = f->f_localsplus + co->co_nlocals;
-    PyObject *co_code = co->co_optimized_code ? co->co_optimized_code : co->co_code;
+    PyObject *co_code = _PyCode_CODE(co);
     assert(PyBytes_Check(co_code));
     assert(PyBytes_GET_SIZE(co_code) <= INT_MAX);
     assert(PyBytes_GET_SIZE(co_code) % sizeof(_Py_CODEUNIT) == 0);
@@ -1499,7 +1499,9 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
             }
 #if OPCACHE_STATS
             opcache_code_objects_extra_mem +=
-                PyBytes_Size(co->co_code) / sizeof(_Py_CODEUNIT) +
+                // While co_optimized_code isn't used until the next
+                // run, we can get away with using it right now.
+                PyBytes_Size(co_code) / sizeof(_Py_CODEUNIT) +
                 sizeof(_PyOpcache) * co->co_opcache_size;
             opcache_code_objects++;
 #endif

--- a/test-optimize.py
+++ b/test-optimize.py
@@ -16,21 +16,27 @@ class Spam:
         self.c = self.c + 1
 
 
-spam = Spam()
-co = spam.inc_slots.__code__
+obj = Spam()
+co = obj.inc_slots.__code__
+
+import zipfile
+obj = zipfile.ZipInfo()
+cls = type(obj)
+co = obj._decodeExtra.__code__
+
+#print(dir(getattr(cls, cls.__slots__[0])))
+#print(f'obj size: {sys.getsizeof(obj)}')
+#print('slots:')
+#for i, name in enumerate(dis._get_slots(cls)):
+#    descr = getattr(cls, name, None)
+#    if descr is not None:
+#        print(f'  {i:>2} {name:20} ({descr})')
 
 print()
 dis.dis(co)
 
-#disassembled = sys.guido(co)
-#print()
-#print('=====')
-#print()
-#dis.dis(disassembled)
-
 print()
 print('=====')
-
-sys.eric(co, spam)
+sys.eric(co, obj)
 print()
 dis.dis(co)


### PR DESCRIPTION
Adds _PyCode_CODE() and fixes dis.dis().

We still have several places where we use `co->co_code` but might need to use `_PyCode_CODE(co)`.  The problem is that we have a single ceval run where `co_optimized_code` is set but we aren't using it.