### PR TITLE
add timing for a second exec loop (no lazy work)

### DIFF
--- a/Lib/test/test_new_pyc.py
+++ b/Lib/test/test_new_pyc.py
@@ -96,8 +96,12 @@ class TestNewPyc(unittest.TestCase):
             for code in codes:
                 exec(code, {})
             t3 = time.time()
-            print(f"{label} exec: {t3-t2:.3f}")
-            print(f"       {label} total: {t3-t0:.3f}")
+            for code in codes:
+                exec(code, {})
+            t4 = time.time()
+            print(f"{label} first exec: {t3-t2:.3f}")
+            print(f"{label} second exec: {t4-t3:.3f}")
+            print(f"       {label} total: {t4-t0:.3f}")
             return t3 - t0
 
         code = compile(source, "<old>", "exec")

--- a/Lib/test/test_new_pyc.py
+++ b/Lib/test/test_new_pyc.py
@@ -75,8 +75,7 @@ class TestNewPyc(unittest.TestCase):
         assert f(1, 10) == 11
         assert f(a=1, b=10) == 11
 
-    def test_speed(self):
-        body = "    a, b = b, a\n"*100
+    def do_test_speed(self, body):
         functions = [
             f"def f{num}(a, b):\n{body}"
             for num in range(100)
@@ -96,10 +95,10 @@ class TestNewPyc(unittest.TestCase):
             for code in codes:
                 exec(code, {})
             t3 = time.time()
+            print(f"{label} first exec: {t3-t2:.3f}")
             for code in codes:
                 exec(code, {})
             t4 = time.time()
-            print(f"{label} first exec: {t3-t2:.3f}")
             print(f"{label} second exec: {t4-t3:.3f}")
             print(f"       {label} total: {t4-t0:.3f}")
             return t3 - t0
@@ -114,6 +113,15 @@ class TestNewPyc(unittest.TestCase):
         if tc and tn:
             print(f"Classic-to-new ratio: {tc/tn:.2f} (new is {100*(tc/tn-1):.0f}% faster)")
 
+    def test_speed_few_locals(self):
+        body = "    a, b = b, a\n"*100
+        self.do_test_speed(body)
+
+    def test_speed_many_locals(self):
+        body = ["    a0, b0 = 1, 1"]
+        for i in range(100):
+            body.append(f"    a{i+1}, b{i+1} = b{i}, a{i}")
+        self.do_test_speed('\n'.join(body))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The second exec (when no lazy work needs to be done) should be equal, right?. I'm getting this:

Starting speed test
Classic load: 0.545
Classic first exec: 0.165
Classic second exec: 0.143
       Classic total: 0.868
New PYC load: 0.000
New PYC first exec: 0.550
New PYC second exec: 0.186
       New PYC total: 0.735

Starting speed test
Classic load: 0.540
Classic first exec: 0.136
Classic second exec: 0.148
       Classic total: 0.825
New PYC load: 0.000
New PYC first exec: 0.531
New PYC second exec: 0.200
       New PYC total: 0.731

Starting speed test
Classic load: 0.534
Classic first exec: 0.148
Classic second exec: 0.158
       Classic total: 0.840
New PYC load: 0.015
New PYC first exec: 0.539
New PYC second exec: 0.195
       New PYC total: 0.748

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
