### PR TITLE
test that calls the functions

### DIFF
--- a/Lib/test/test_new_pyc.py
+++ b/Lib/test/test_new_pyc.py
@@ -132,7 +132,7 @@ class TestNewPyc(unittest.TestCase):
         body = ["    a0, b0 = 1, 1"]
         for i in range(100):
             body.append(f"    a{i+1}, b{i+1} = b{i}, a{i}")
-        self.do_test_speed('\n'.join(body), "many_locals", call=True)
+        self.do_test_speed('\n'.join(body), "many_locals_with_call", call=True)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_new_pyc.py
+++ b/Lib/test/test_new_pyc.py
@@ -75,11 +75,16 @@ class TestNewPyc(unittest.TestCase):
         assert f(1, 10) == 11
         assert f(a=1, b=10) == 11
 
-    def do_test_speed(self, body, test_name):
+    def do_test_speed(self, body, test_name, call=False):
         functions = [
             f"def f{num}(a, b):\n{body}"
             for num in range(100)
         ]
+        if call:
+            functions.extend([
+                f"\nf{num}({num}, {num+1})\n"
+                for num in range(100)]
+            )
         source = "\n\n".join(functions)
         print(f"Starting {test_name} speed test")
 
@@ -122,6 +127,12 @@ class TestNewPyc(unittest.TestCase):
         for i in range(100):
             body.append(f"    a{i+1}, b{i+1} = b{i}, a{i}")
         self.do_test_speed('\n'.join(body), "many_locals")
+
+    def test_speed_many_locals_with_call(self):
+        body = ["    a0, b0 = 1, 1"]
+        for i in range(100):
+            body.append(f"    a{i+1}, b{i+1} = b{i}, a{i}")
+        self.do_test_speed('\n'.join(body), "many_locals", call=True)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_new_pyc.py
+++ b/Lib/test/test_new_pyc.py
@@ -77,14 +77,9 @@ class TestNewPyc(unittest.TestCase):
 
     def do_test_speed(self, body, test_name, call=False):
         functions = [
-            f"def f{num}(a, b):\n{body}"
+            f"def f(a, b):\n{body}%s" % (f"\nf(0,0)\n" if call else "")
             for num in range(100)
         ]
-        if call:
-            functions.extend([
-                f"\nf{num}({num}, {num+1})\n"
-                for num in range(100)]
-            )
         source = "\n\n".join(functions)
         print(f"Starting {test_name} speed test")
 

--- a/Lib/test/test_new_pyc.py
+++ b/Lib/test/test_new_pyc.py
@@ -100,7 +100,15 @@ class TestNewPyc(unittest.TestCase):
                 exec(code, {})
             t4 = time.perf_counter()
             print(f"{label} second exec: {t4-t3:.3f}")
-            print(f"       {label} total: {t4-t0:.3f}")
+            for code in codes:
+                exec(code, {})
+            t5 = time.perf_counter()
+            print(f"{label} third exec: {t5-t4:.3f}")
+            for code in codes:
+                exec(code, {})
+            t6 = time.perf_counter()
+            print(f"{label} fourth exec: {t6-t5:.3f}")
+            print(f"       {label} total: {t6-t0:.3f}")
             return t3 - t0
 
         code = compile(source, "<old>", "exec")


### PR DESCRIPTION
> .\python.bat -m test test_new_pyc -m test_speed_many_locals_with_call
Running Release|x64 interpreter...
0:00:00 Run tests sequentially
0:00:00 [1/1] test_new_pyc
Starting many_locals speed test
Classic load: 4.382
Classic first exec: 5.509
Classic second exec: 5.234
       Classic total: 15.126
test test_new_pyc failed -- Traceback (most recent call last):
  File "C:\Users\User\src\guido-cpython\lib\test\test_new_pyc.py", line 135, in test_speed_many_locals_with_call
    self.do_test_speed('\n'.join(body), "many_locals", call=True)
  File "C:\Users\User\src\guido-cpython\lib\test\test_new_pyc.py", line 115, in do_test_speed
    data = pyco.serialize_source(source, "<new>")
  File "C:\Users\User\src\guido-cpython\Tools\pyco\pyco.py", line 597, in serialize_source
    data = builder.get_bytes()
  File "C:\Users\User\src\guido-cpython\Tools\pyco\pyco.py", line 538, in get_bytes
    code_offsets = helper(self.codeobjs, "code")
  File "C:\Users\User\src\guido-cpython\Tools\pyco\pyco.py", line 531, in helper
    binary_data += thing.get_bytes()
  File "C:\Users\User\src\guido-cpython\Tools\pyco\pyco.py", line 394, in get_bytes
    new_bytecode = rewritten_bytecode(code, self.builder, self.index)
  File "C:\Users\User\src\guido-cpython\Tools\pyco\pyco.py", line 235, in rewritten_bytecode
    raise RuntimeError(
RuntimeError: More than 256 constants in original <module> at line 1


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
