### PR TITLE
display summary and breakdown of timing tests

### DIFF
--- a/Lib/test/test_new_pyc.py
+++ b/Lib/test/test_new_pyc.py
@@ -164,7 +164,7 @@ class TestNewPycSpeed(unittest.TestCase):
                 tc = f(classic_timings)
                 tn = f(new_timings)
                 print(f">> {title} ratio: {tn/tc:.2f} "
-                      f"(new is {100*(tn/tc-1):.0f}% faster)")
+                      f"(new is {100*(tc/tn-1):.0f}% faster)")
                 return tn/tc
 
             print("Classic-to-new comparison:")

--- a/Lib/test/test_new_pyc.py
+++ b/Lib/test/test_new_pyc.py
@@ -1,6 +1,7 @@
 """Test for new PYC format"""
 
 import dis
+import gc
 import marshal
 import time
 import unittest
@@ -104,6 +105,10 @@ class TestNewPycSpeed(unittest.TestCase):
             print(f"{t:25}{r[0]:15.3f}{r[1]:15.3f}")
         print()
         cls.results = {}
+
+    def setUp(self):
+        while gc.collect():
+            pass
 
     def do_test_speed(self, body, call=False):
         NUM_FUNCS = 100

--- a/Lib/test/test_new_pyc.py
+++ b/Lib/test/test_new_pyc.py
@@ -163,9 +163,9 @@ class TestNewPycSpeed(unittest.TestCase):
             def comparison(title, f):
                 tc = f(classic_timings)
                 tn = f(new_timings)
-                print(f">> {title} ratio: {tc/tn:.2f} "
-                      f"(new is {100*(tc/tn-1):.0f}% faster)")
-                return tc/tn
+                print(f">> {title} ratio: {tn/tc:.2f} "
+                      f"(new is {100*(tn/tc-1):.0f}% faster)")
+                return tn/tc
 
             print("Classic-to-new comparison:")
             self.results[self._testMethodName.lstrip('test_speed_')] = [


### PR DESCRIPTION

This change makes the classic version slower. There was something unfair about the previous test when names were repeated between the functions. I think marshal was able to benefit from caching or interning or something which the new method was not.



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
