### PR TITLE
fix co_filename

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -261,6 +261,7 @@ struct _PyCodeConstructor {
 PyAPI_FUNC(int) _PyCode_Validate(struct _PyCodeConstructor *);
 PyAPI_FUNC(PyCodeObject *) _PyCode_New(struct _PyCodeConstructor *);
 PyAPI_FUNC(PyCodeObject *) _PyCode_Update(struct _PyCodeConstructor *, PyCodeObject *);
+PyAPI_FUNC(void) _PyCode_Update_Filenames(PyCodeObject *co, PyObject *oldname, PyObject *newname);
 
 
 /* Private API */

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -261,7 +261,7 @@ struct _PyCodeConstructor {
 PyAPI_FUNC(int) _PyCode_Validate(struct _PyCodeConstructor *);
 PyAPI_FUNC(PyCodeObject *) _PyCode_New(struct _PyCodeConstructor *);
 PyAPI_FUNC(PyCodeObject *) _PyCode_Update(struct _PyCodeConstructor *, PyCodeObject *);
-PyAPI_FUNC(void) _PyCode_Update_Filenames(PyCodeObject *co, PyObject *oldname, PyObject *newname);
+PyAPI_FUNC(void) _PyCode_UpdateFilenames(PyCodeObject *co, PyObject *oldname, PyObject *newname);
 
 
 /* Private API */

--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -151,6 +151,9 @@ def compile(file, cfile=None, dfile=None, doraise=False, optimize=-1,
             else:
                 sys.stderr.write(py_exc.msg + '\n')
         return
+    if dfile is not None:
+        import _imp
+        _imp._fix_co_filename(code, file)
     try:
         dirname = os.path.dirname(cfile)
         if dirname:

--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -151,9 +151,6 @@ def compile(file, cfile=None, dfile=None, doraise=False, optimize=-1,
             else:
                 sys.stderr.write(py_exc.msg + '\n')
         return
-    if dfile is not None:
-        import _imp
-        _imp._fix_co_filename(code, file)
     try:
         dirname = os.path.dirname(cfile)
         if dirname:

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -430,6 +430,28 @@ _PyCode_New(struct _PyCodeConstructor *con)
     return co;
 }
 
+void
+_PyCode_Update_Filenames(PyCodeObject *co, PyObject *oldname, PyObject *newname)
+{
+    PyObject *constants, *tmp;
+    Py_ssize_t i, n;
+
+    if (PyUnicode_Compare(co->co_filename, oldname))
+        return;
+
+    Py_INCREF(newname);
+    Py_XSETREF(co->co_filename, newname);
+
+    constants = co->co_consts;
+    n = constants != NULL ? PyTuple_GET_SIZE(constants) : 0;
+    for (i = 0; i < n; i++) {
+        tmp = PyTuple_GET_ITEM(constants, i);
+        if (PyCode_Check(tmp))
+            _PyCode_Update_Filenames((PyCodeObject *)tmp,
+                oldname, newname);
+    }
+}
+
 PyCodeObject *
 _PyCode_Update(struct _PyCodeConstructor *con, PyCodeObject *code)
 {
@@ -447,11 +469,16 @@ _PyCode_Update(struct _PyCodeConstructor *con, PyCodeObject *code)
         con->columntable = Py_None;
     }
 
-    Py_XDECREF(code->co_filename);
+    PyObject *newname = code->co_filename;
     Py_XDECREF(code->co_name);
     Py_XDECREF(code->co_qualname);
 
     init_code(code, con);
+
+    if (newname) {
+        _PyCode_Update_Filenames(code, code->co_filename, newname);
+        Py_DECREF(newname);
+    }
 
     return code;
 }

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -470,15 +470,14 @@ _PyCode_Update(struct _PyCodeConstructor *con, PyCodeObject *code)
     }
 
     PyObject *newname = code->co_filename;
-    Py_XDECREF(code->co_name);
-    Py_XDECREF(code->co_qualname);
+    Py_DECREF(code->co_name);
+    Py_DECREF(code->co_qualname);
 
     init_code(code, con);
 
-    if (newname) {
-        _PyCode_UpdateFilenames(code, code->co_filename, newname);
-        Py_DECREF(newname);
-    }
+    assert(newname);
+    _PyCode_UpdateFilenames(code, code->co_filename, newname);
+    Py_DECREF(newname);
 
     return code;
 }

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -431,7 +431,7 @@ _PyCode_New(struct _PyCodeConstructor *con)
 }
 
 void
-_PyCode_Update_Filenames(PyCodeObject *co, PyObject *oldname, PyObject *newname)
+_PyCode_UpdateFilenames(PyCodeObject *co, PyObject *oldname, PyObject *newname)
 {
     PyObject *constants, *tmp;
     Py_ssize_t i, n;
@@ -447,7 +447,7 @@ _PyCode_Update_Filenames(PyCodeObject *co, PyObject *oldname, PyObject *newname)
     for (i = 0; i < n; i++) {
         tmp = PyTuple_GET_ITEM(constants, i);
         if (PyCode_Check(tmp))
-            _PyCode_Update_Filenames((PyCodeObject *)tmp,
+            _PyCode_UpdateFilenames((PyCodeObject *)tmp,
                 oldname, newname);
     }
 }
@@ -476,7 +476,7 @@ _PyCode_Update(struct _PyCodeConstructor *con, PyCodeObject *code)
     init_code(code, con);
 
     if (newname) {
-        _PyCode_Update_Filenames(code, code->co_filename, newname);
+        _PyCode_UpdateFilenames(code, code->co_filename, newname);
         Py_DECREF(newname);
     }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -824,28 +824,6 @@ PyImport_ExecCodeModuleObject(PyObject *name, PyObject *co, PyObject *pathname,
 
 
 static void
-update_code_filenames(PyCodeObject *co, PyObject *oldname, PyObject *newname)
-{
-    PyObject *constants, *tmp;
-    Py_ssize_t i, n;
-
-    if (PyUnicode_Compare(co->co_filename, oldname))
-        return;
-
-    Py_INCREF(newname);
-    Py_XSETREF(co->co_filename, newname);
-
-    constants = co->co_consts;
-    n = constants != NULL ? PyTuple_GET_SIZE(constants) : 0;
-    for (i = 0; i < n; i++) {
-        tmp = PyTuple_GET_ITEM(constants, i);
-        if (PyCode_Check(tmp))
-            update_code_filenames((PyCodeObject *)tmp,
-                                  oldname, newname);
-    }
-}
-
-static void
 update_compiled_module(PyCodeObject *co, PyObject *newname)
 {
     PyObject *oldname;
@@ -855,7 +833,7 @@ update_compiled_module(PyCodeObject *co, PyObject *newname)
 
     oldname = co->co_filename;
     Py_INCREF(oldname);
-    update_code_filenames(co, oldname, newname);
+    _PyCode_Update_Filenames(co, oldname, newname);
     Py_DECREF(oldname);
 }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -833,7 +833,7 @@ update_compiled_module(PyCodeObject *co, PyObject *newname)
 
     oldname = co->co_filename;
     Py_INCREF(oldname);
-    _PyCode_Update_Filenames(co, oldname, newname);
+    _PyCode_UpdateFilenames(co, oldname, newname);
     Py_DECREF(oldname);
 }
 


### PR DESCRIPTION

This change fixes test_incorrect_code_name but breaks test_module_without_source. 

I have two questions:

1. Why is test_module_without_source expecting a different result than test_incorrect_code_name?

2. Why was this change not needed for test_incorrect_code_name  to work before lazy marshal?


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
