### PR TITLE
[generate-ceval-switch] GH-98831: "Generate" the interpreter (GH-98830)

### DIFF
--- a/Tools/cases_generator/lexer.py
+++ b/Tools/cases_generator/lexer.py
@@ -245,7 +245,7 @@ def to_text(tkns: list[Token], dedent: int = 0) -> str:
     return ''.join(res)
 
 
-if __name__ == "__main__":
+def main():
     import sys
     filename = sys.argv[1]
     if filename == "-c":
@@ -255,3 +255,7 @@ if __name__ == "__main__":
     # print(to_text(tokenize(src)))
     for tkn in tokenize(src, filename=filename):
         print(tkn)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/cases_generator/parser.py
+++ b/Tools/cases_generator/parser.py
@@ -134,7 +134,7 @@ class Parser(sparser.SParser):
         return None
 
 
-if __name__ == "__main__":
+def main():
     import sys
     filename = sys.argv[1]
     with open(filename) as f:
@@ -146,3 +146,7 @@ if __name__ == "__main__":
     parser = Parser(src, filename)
     x = parser.inst_def()
     print(x)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/cases_generator/plexer.py
+++ b/Tools/cases_generator/plexer.py
@@ -83,7 +83,7 @@ class PLexer:
             self.filename, tkn.line, tkn.column, self.extract_line(tkn.line))
 
 
-if __name__ == "__main__":
+def main():
     import sys
     if sys.argv[1:]:
         filename = sys.argv[1]
@@ -102,3 +102,7 @@ if __name__ == "__main__":
         left = repr(tok)
         right = lx.to_text([tok]).rstrip()
         print(f"{left:40.40} {right}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/cases_generator/sparser.py
+++ b/Tools/cases_generator/sparser.py
@@ -301,7 +301,7 @@ class SParser(EParser):
                                 return VarDecl(type, name, None)
 
 
-if __name__ == "__main__":
+def main():
     import sys
     if sys.argv[1:]:
         filename = sys.argv[1]
@@ -333,3 +333,7 @@ if __name__ == "__main__":
         print(x)
         print("=== === ===")
         print("OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I noticed that some files in `Tools/cases_generator/` have their code in the `main()` function, but others don't. This PR proposes to move `lexer.py`, `parser.py`, `plexer.py` and `sparser.py` main code to a `main()` function for consistency.
