### PR TITLE
Disallow TAGSTRING_START after the conversion character in an f-string

### DIFF
--- a/Parser/tokenizer.h
+++ b/Parser/tokenizer.h
@@ -52,6 +52,8 @@ typedef struct _tokenizer_mode {
     const char* f_string_start;
     const char* f_string_multi_line_start;
 
+    int f_string_conversion;
+
     Py_ssize_t f_string_start_offset;
     Py_ssize_t f_string_multi_line_start_offset;
 


### PR DESCRIPTION
Opening this, just so you know what I meant in https://github.com/jimbaker/tagstr/issues/22#issuecomment-1524680437 and because I'll be on a plane the whole day tomorrow.

This PR solves 3/5 failures in `test_fstring` with the other two being related to what I wrote in https://github.com/jimbaker/tagstr/issues/22#issuecomment-1524693168.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
